### PR TITLE
Improved simple contrast enhancement

### DIFF
--- a/raspivoice/KeyboardInput.cpp
+++ b/raspivoice/KeyboardInput.cpp
@@ -200,7 +200,7 @@ std::string KeyboardInput::GetInteractiveCommandList()
 	cmdlist << "4: Edge detection [off, 50%%, 100%%]" << std::endl;
 	cmdlist << "5: Threshold [off, 25%%, 50%%, 75%%]" << std::endl;
 	cmdlist << "6: Brightness [low, normal, high]" << std::endl;
-	cmdlist << "7: Contrast [x1, x2, x3]" << std::endl;
+	cmdlist << "7: Contrast [x0, x1, x2, x3]" << std::endl;
 	cmdlist << "8: Foveal mapping [off, on]" << std::endl;
 	cmdlist << ".: Restore defaults" << std::endl;
 	cmdlist << "q, [Escape]: Quit" << std::endl;
@@ -363,7 +363,7 @@ std::string KeyboardInput::KeyPressedAction(int ch)
 				}
 				break;
 			case '7':
-				cycleValues(rvopt.contrast, { 1.0, 2.0, 3.0 }, changevalue);
+				cycleValues(rvopt.contrast, { 0.0, 1.0, 2.0, 3.0 }, changevalue);
 				state_str << "contrast factor " << rvopt.contrast;
 				break;
 			case '8':

--- a/raspivoice/Options.cpp
+++ b/raspivoice/Options.cpp
@@ -70,7 +70,7 @@ RaspiVoiceOptions GetDefaultOptions()
 	opt.read_frames = 2;
 	opt.exposure = 0;
 	opt.brightness = 0;
-	opt.contrast = 1.0;
+	opt.contrast = 2.0;
 	opt.blinders = 0;
 	opt.zoom = 1;
 	opt.foveal_mapping = false;
@@ -276,7 +276,7 @@ void ShowHelp()
 	std::cout << "-R, --read_frames=[2]\t\t\tSet number of frames to read from camera before processing (>= 1). Optimize for minimal lag." << std::endl;
 	std::cout << "-e  --exposure=[0]\t\t\tCamera exposure time setting, 1-100. Use 0 for auto." << std::endl;
 	std::cout << "-B  --brightness=[0]\t\t\tAdditional brightness, -255 to 255." << std::endl;
-	std::cout << "-C  --contrast=[1.0]\t\t\tContrast enhancement factor >= 1.0" << std::endl;
+	std::cout << "-C  --contrast=[2.0]\t\t\tContrast enhancement factor >= 0.0" << std::endl;
 	std::cout << "-b  --blinders=[0]\t\t\tBlinders left and right, pixel size (0-89 for default columns)" << std::endl;
 	std::cout << "-z  --zoom=[1.0]\t\t\tZoom factor (>= 1.0)" << std::endl;
 	std::cout << "-m  --foveal_mapping\t\t\tEnable foveal mapping (barrel distortion magnifying center region)" << std::endl;

--- a/raspivoice/RaspiVoice.cpp
+++ b/raspivoice/RaspiVoice.cpp
@@ -308,16 +308,23 @@ void RaspiVoice::processImage(cv::Mat rawImage)
 			processedImage(cv::Rect(columns - 1 - opt.blinders, 0, opt.blinders, rows - 1)).setTo(0);
 		}
 
-		if ((opt.contrast != 1.0) || (opt.brightness != 0))
+		if (opt.contrast != 0.0)  // Set default value for opt.contrast to 2.0
 		{
-			float alpha = opt.contrast;
-			int beta = opt.brightness;
-
+			float avg = 0.0;    
 			for (int y = 0; y < processedImage.rows; y++)
 			{
 				for (int x = 0; x < processedImage.cols; x++)
 				{
-					processedImage.at<uchar>(y, x) = cv::saturate_cast<uchar>(alpha*(processedImage.at<uchar>(y, x)) + beta);
+					avg += processedImage.at<uchar>(y, x);
+				}
+			}
+			avg = avg / (processedImage.rows * processedImage.cols);
+			for (int y = 0; y < processedImage.rows; y++)
+			{
+				for (int x = 0; x < processedImage.cols; x++)
+				{
+					int mVal = processedImage.at<uchar>(y, x);
+					processedImage.at<uchar>(y, x) = cv::saturate_cast<uchar>(mVal + opt.contrast*(mVal - avg));
 				}
 			}
 		}

--- a/raspivoice_standalone/KeyboardInput.cpp
+++ b/raspivoice_standalone/KeyboardInput.cpp
@@ -200,7 +200,7 @@ std::string KeyboardInput::GetInteractiveCommandList()
 	cmdlist << "4: Edge detection [off, 50%%, 100%%]" << std::endl;
 	cmdlist << "5: Threshold [off, 25%%, 50%%, 75%%]" << std::endl;
 	cmdlist << "6: Brightness [low, normal, high]" << std::endl;
-	cmdlist << "7: Contrast [x1, x2, x3]" << std::endl;
+	cmdlist << "7: Contrast [x0, x1, x2, x3]" << std::endl;
 	cmdlist << "8: Foveal mapping [off, on]" << std::endl;
 	cmdlist << ".: Restore defaults" << std::endl;
 	cmdlist << "q, [Escape]: Quit" << std::endl;
@@ -363,7 +363,7 @@ std::string KeyboardInput::KeyPressedAction(int ch)
 				}
 				break;
 			case '7':
-				cycleValues(rvopt.contrast, { 1.0, 2.0, 3.0 }, changevalue);
+				cycleValues(rvopt.contrast, { 0.0, 1.0, 2.0, 3.0 }, changevalue);
 				state_str << "contrast factor " << rvopt.contrast;
 				break;
 			case '8':

--- a/raspivoice_standalone/Options.cpp
+++ b/raspivoice_standalone/Options.cpp
@@ -70,7 +70,7 @@ RaspiVoiceOptions GetDefaultOptions()
 	opt.read_frames = 2;
 	opt.exposure = 0;
 	opt.brightness = 0;
-	opt.contrast = 1.0;
+	opt.contrast = 2.0;
 	opt.blinders = 0;
 	opt.zoom = 1;
 	opt.foveal_mapping = false;
@@ -276,7 +276,7 @@ void ShowHelp()
 	std::cout << "-R, --read_frames=[2]\t\t\tSet number of frames to read from camera before processing (>= 1). Optimize for minimal lag." << std::endl;
 	std::cout << "-e  --exposure=[0]\t\t\tCamera exposure time setting, 1-100. Use 0 for auto." << std::endl;
 	std::cout << "-B  --brightness=[0]\t\t\tAdditional brightness, -255 to 255." << std::endl;
-	std::cout << "-C  --contrast=[1.0]\t\t\tContrast enhancement factor >= 1.0" << std::endl;
+	std::cout << "-C  --contrast=[2.0]\t\t\tContrast enhancement factor >= 0.0" << std::endl;
 	std::cout << "-b  --blinders=[0]\t\t\tBlinders left and right, pixel size (0-89 for default columns)" << std::endl;
 	std::cout << "-z  --zoom=[1.0]\t\t\tZoom factor (>= 1.0)" << std::endl;
 	std::cout << "-m  --foveal_mapping\t\t\tEnable foveal mapping (barrel distortion magnifying center region)" << std::endl;

--- a/raspivoice_standalone/RaspiVoice.cpp
+++ b/raspivoice_standalone/RaspiVoice.cpp
@@ -305,16 +305,23 @@ void RaspiVoice::processImage(cv::Mat rawImage)
 			processedImage(cv::Rect(columns - 1 - opt.blinders, 0, opt.blinders, rows - 1)).setTo(0);
 		}
 
-		if ((opt.contrast != 1.0) || (opt.brightness != 0))
+		if (opt.contrast != 0.0)  // Set default value for opt.contrast to 2.0
 		{
-			float alpha = opt.contrast;
-			int beta = opt.brightness;
-
+			float avg = 0.0;    
 			for (int y = 0; y < processedImage.rows; y++)
 			{
 				for (int x = 0; x < processedImage.cols; x++)
 				{
-					processedImage.at<uchar>(y, x) = cv::saturate_cast<uchar>(alpha*(processedImage.at<uchar>(y, x)) + beta);
+					avg += processedImage.at<uchar>(y, x);
+				}
+			}
+			avg = avg / (processedImage.rows * processedImage.cols);
+			for (int y = 0; y < processedImage.rows; y++)
+			{
+				for (int x = 0; x < processedImage.cols; x++)
+				{
+					int mVal = processedImage.at<uchar>(y, x);
+					processedImage.at<uchar>(y, x) = cv::saturate_cast<uchar>(mVal + opt.contrast*(mVal - avg));
 				}
 			}
 		}


### PR DESCRIPTION
Improved yet still simple contrast enhancement, based on the contrast enhancement as now included with https://www.seeingwithsound.com/hificode_OpenCV.cpp and discussed at https://www.raspberrypi.org/forums/viewtopic.php?f=41&t=49634&p=942554 

Note: Did not remove the now redundant opt.brightness setting yet.
